### PR TITLE
Dependences ATC have been added

### DIFF
--- a/scripts/packages/galera.spec
+++ b/scripts/packages/galera.spec
@@ -91,6 +91,21 @@ BuildRequires: systemd
 %define systemd 0
 %endif
 
+%ifarch ppc64le 
+%if 0%{?rhel} >= 7
+Requires: advance-toolchain-at8.0-rc1-runtime
+%endif
+AutoReq: 0
+%endif
+
+%ifarch ppc64
+%if 0%{?rhel} >= 7
+Requires: advance-toolchain-at8.0-runtime
+%else 
+Requires: advance-toolchain-at7.0-runtime
+%endif
+AutoReq: 0
+%endif
 
 Requires:      openssl nmap
 


### PR DESCRIPTION
I've add dependence from ATC package, there are different on different platforms.

And I've turned off auto requirements, because in case when auto requirements are added the galera package depends on libraries from ATC, but not from ATC package and it is inconvenience - you have to install ATC first and only after that - galera and MDBEc