### PR TITLE
BUG has been fixed under RHEL 7.1 ppc64le ATC-8.0.3-RC1

### DIFF
--- a/galerautils/src/gu_vec16.h
+++ b/galerautils/src/gu_vec16.h
@@ -50,7 +50,8 @@ static GU_FORCE_INLINE gu_vec16_t
 gu_vec16_xor (gu_vec16_t l, gu_vec16_t r)
 {
     gu_vec16_t ret;
-    ret.vec_ = (l.vec_ ^ r.vec_);
+    ret.int_[0] = (l.int_[0] ^ r.int_[0]);
+    ret.int_[1] = (l.int_[1] ^ r.int_[1]);
     return ret;
 }
 


### PR DESCRIPTION
BUG has been fixed under RHEL 7.1 ppc64le ATC-8.0.3-RC1:
    xor operation for gu_vec16 doesn't work correctly:
    
    $ ./scripts/build.sh -r 25.3.9 -p
    ...
    Running suite(s):
    Vector math
    0x0 0x0 0x6 0xA 0x14 0x1C 0x22 0x36 0x48 0x58 0x6E 0x72 0x9C 0xA4 0xCA 0xEE
    0x48 0x58 0x6E 0x72 0x9C 0xA4 0xCA 0xEE 0x0 0x0 0x6 0xA 0x14 0x1C 0x22 0x36
    0%: Checks: 1, Failures: 1, Errors: 0
    galerautils/tests/gu_vec_test.c:49:F:vec16:vec16_test:0: Failure '!gu_vec16_eq(v3, v2)' occured
    ...
